### PR TITLE
Adjust test2 to pass

### DIFF
--- a/tests/test2/expected.txt
+++ b/tests/test2/expected.txt
@@ -28,7 +28,7 @@ Code
 null
 22b
 1
-20
+0
 NaN
 40815c70a3d70a3d
 0x0.0p0


### PR DESCRIPTION
I was running enjarify.runtests from the v1.0.3 checkout, and test2 failed with one difference (see patch). I'm assuming the test is wrong, but if not — please treat this as an issue report.