### PR TITLE
runtests: drop -Xss param

### DIFF
--- a/enjarify/runtests.py
+++ b/enjarify/runtests.py
@@ -32,7 +32,7 @@ def executeTest(name, opts):
     classes.update(STUB_FILES)
     writeToJar('out.jar', classes)
 
-    result = subprocess.check_output("java -Xss515m -jar out.jar a.a".split(),
+    result = subprocess.check_output("java -jar out.jar a.a".split(),
         stderr=subprocess.STDOUT,
         universal_newlines=True)
     expected = read(os.path.join(dir, 'expected.txt'), 'r')


### PR DESCRIPTION
With -Xss515m, java will not start on 32 bit platforms (i686, arm7hl):
$ java -Xss515m -jar out.jar a.a
Error occurred during initialization of VM
java.lang.OutOfMemoryError: unable to create new native thread