### PR TITLE
Fix IR generation when Switch is replaced with GOTO.

### DIFF
--- a/enjarify/jvm/writeir.py
+++ b/enjarify/jvm/writeir.py
@@ -161,6 +161,7 @@ class IRBlock:
         if jumps:
             self.add(ir.Switch(default, jumps))
         else:
+            self.u8(ir.POP)
             self.goto(default)
 
     def generateExceptLabels(self):


### PR DESCRIPTION
In cases, where all targets of a switch are the same as the default
target, this switch is replaced by a GOTO instruction. This leaves the
operand of the switch on the stack. This commit adds a POP instruction
before the GOTO, to remove this value.

It might be better to not push the value at all, but I wanted to do the least amount of changes.
I've checked your rust implementation and it has the same problem.