### PR TITLE
Update enjarify.bat

### DIFF
--- a/enjarify.bat
+++ b/enjarify.bat
@@ -15,4 +15,4 @@ REM  See the License for the specific language governing permissions and
 REM  limitations under the License.
 
 set PYTHONPATH=%~dp0
-python3 -O -m enjarify.main %*
+py -3 -O -m enjarify.main %*


### PR DESCRIPTION
There is no python3 alias under Windows